### PR TITLE
Add WebMock adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR [#7](https://github.com/palkan/isolator/pull/7)] Add WebMock adapter. ([@palkan][])
+
 - Add `ignore_if` modifier to adapter. ([@palkan][])
 
 - [PR [#5](https://github.com/palkan/isolator/pull/5)] Add `mail` adapter. ([@alexshgov][])

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Isolator has a bunch of built-in adapters:
 - `:active_job`
 - `:sidekiq`
 - `:mailer`
+- `:webmock` – track mocked HTTP requests (unseen by Sniffer) in tests
 
 You can dynamically enable/disable adapters, e.g.:
 

--- a/isolator.gemspec
+++ b/isolator.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "uniform_notifier", "~> 1.11"
   spec.add_development_dependency "sidekiq", "~> 5.0"
+  spec.add_development_dependency "webmock", "~> 3.1"
 end

--- a/lib/isolator/adapter_builder.rb
+++ b/lib/isolator/adapter_builder.rb
@@ -5,7 +5,7 @@ require "isolator/adapters/base"
 module Isolator
   # Builds adapter from provided params
   module AdapterBuilder
-    def self.call(target, method_name, **options)
+    def self.call(target: nil, method_name: nil, **options)
       adapter = Module.new do
         extend Isolator::Adapters::Base
 
@@ -13,14 +13,15 @@ module Isolator
         self.exception_message = options[:exception_message] if options.key?(:exception_message)
       end
 
-      add_patch_method adapter, target, method_name
+      add_patch_method(adapter, target, method_name) if
+        target && method_name
       adapter
     end
 
     def self.add_patch_method(adapter, base, method_name)
       mod = Module.new do
         define_method method_name do |*args, &block|
-          adapter.notify(caller) if adapter.notify_isolator?(*args)
+          adapter.notify(caller, *args)
           super(*args, &block)
         end
       end

--- a/lib/isolator/adapters/background_jobs/active_job.rb
+++ b/lib/isolator/adapters/background_jobs/active_job.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-Isolator.isolate :active_job, ActiveJob::Base,
-                 :enqueue, exception_class: Isolator::BackgroundJobError
+Isolator.isolate :active_job,
+                 target: ActiveJob::Base,
+                 method_name: :enqueue,
+                 exception_class: Isolator::BackgroundJobError

--- a/lib/isolator/adapters/background_jobs/sidekiq.rb
+++ b/lib/isolator/adapters/background_jobs/sidekiq.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
-Isolator.isolate :sidekiq, Sidekiq::Client,
-                 :raw_push, exception_class: Isolator::BackgroundJobError
+Isolator.isolate :sidekiq,
+                 target: Sidekiq::Client,
+                 method_name: :raw_push,
+                 exception_class: Isolator::BackgroundJobError

--- a/lib/isolator/adapters/base.rb
+++ b/lib/isolator/adapters/base.rb
@@ -18,11 +18,12 @@ module Isolator
         @disabled != true
       end
 
-      def notify(backtrace)
+      def notify(backtrace, *args)
+        return unless notify?(*args)
         Isolator.notify(exception: build_exception, backtrace: backtrace)
       end
 
-      def notify_isolator?(*args)
+      def notify?(*args)
         enabled? && Isolator.within_transaction? && !ignored?(*args)
       end
 

--- a/lib/isolator/adapters/http.rb
+++ b/lib/isolator/adapters/http.rb
@@ -1,20 +1,5 @@
 # frozen_string_literal: true
 
-require "sniffer"
+require "isolator/adapters/http/sniffer"
 
-Sniffer.config do |c|
-  # Disable Sniffer logger
-  c.logger = Logger.new(IO::NULL)
-end
-
-Isolator.isolate :http, Sniffer.singleton_class,
-                 :store, exception_class: Isolator::HTTPError
-
-Isolator.before_isolate do
-  Sniffer.enable!
-end
-
-Isolator.after_isolate do
-  Sniffer.clear!
-  Sniffer.disable!
-end
+require "isolator/adapters/http/webmock" if defined?(::WebMock)

--- a/lib/isolator/adapters/http/sniffer.rb
+++ b/lib/isolator/adapters/http/sniffer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "sniffer"
+
+Sniffer.config do |c|
+  # Disable Sniffer logger
+  c.logger = Logger.new(IO::NULL)
+end
+
+Isolator.isolate :http, target: Sniffer.singleton_class,
+                        method_name: :store,
+                        exception_class: Isolator::HTTPError
+
+Isolator.before_isolate do
+  Sniffer.enable!
+end
+
+Isolator.after_isolate do
+  Sniffer.clear!
+  Sniffer.disable!
+end

--- a/lib/isolator/adapters/http/webmock.rb
+++ b/lib/isolator/adapters/http/webmock.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+adapter = Isolator.isolate :webmock, exception_class: Isolator::HTTPError
+
+WebMock.after_request do |*args|
+  adapter.notify(caller, *args)
+end

--- a/lib/isolator/adapters/mailers/mail.rb
+++ b/lib/isolator/adapters/mailers/mail.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-Isolator.isolate :mailer, Mail::Message, :deliver,
-                 exception_class: Isolator::MailerError
+Isolator.isolate :mailer, target: Mail::Message, method_name: :deliver,
+                          exception_class: Isolator::MailerError

--- a/lib/isolator/isolate.rb
+++ b/lib/isolator/isolate.rb
@@ -3,9 +3,9 @@
 module Isolator
   # Add .isolate function to build and register adapters
   module Isolate
-    def isolate(id, target_module, method_name, **options)
+    def isolate(id, **options)
       raise "Adapter already registered: #{id}" if Isolator.adapters.key?(id.to_s)
-      adapter = AdapterBuilder.call(target_module, method_name, **options)
+      adapter = AdapterBuilder.call(**options)
       Isolator.adapters[id.to_s] = adapter
     end
   end

--- a/spec/integrations/fixtures/rspec/webmock_fixture.rb
+++ b/spec/integrations/fixtures/rspec/webmock_fixture.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+ENV["RAILS_ENV"] = "test"
+
+$LOAD_PATH.unshift File.expand_path("../../../../../lib", __FILE__)
+
+require "webmock"
+require_relative "../../../support/rails_app"
+
+require "net/http"
+require "rspec/rails"
+require "webmock/rspec"
+
+require "isolator"
+
+RSpec.configure do |config|
+  config.use_transactional_fixtures = true
+end
+
+describe "HTTP calls with WebMock" do
+  before { stub_request(:any, "www.example.com") }
+
+  subject { Net::HTTP.get("www.example.com", "/") }
+
+  it "doesn't raise when no transaction", :no_transaction do
+    expect { subject }.not_to raise_error
+  end
+
+  it "raises with transaction", :offense do
+    User.transaction do
+      subject
+    end
+    expect(true).to eq true
+  end
+end

--- a/spec/integrations/webmock_spec.rb
+++ b/spec/integrations/webmock_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "WebMock integration" do
+  context "RSpec" do
+    specify do
+      output = run_rspec("webmock")
+
+      expect(output).to include("2 examples, 1 failure")
+      expect(output).to include("Isolator::HTTPError")
+    end
+  end
+end

--- a/spec/isolator/adapters/base_spec.rb
+++ b/spec/isolator/adapters/base_spec.rb
@@ -10,7 +10,8 @@ describe "Base adapter" do
       end
     end
 
-    Isolator.isolate :test, ::Isolator::Danger.singleton_class, :call
+    Isolator.isolate :test, target: ::Isolator::Danger.singleton_class,
+                            method_name: :call
   end
 
   after(:all) do


### PR DESCRIPTION
WebMock inject itself before any HTTP implementation, thus
Sniffer doesn't work.

We use `WebMock.after_request` callback to track mocked HTTP requests.