### PR TITLE
Cleanup tests

### DIFF
--- a/spec/isolator/adapters/http/sniffer_spec.rb
+++ b/spec/isolator/adapters/http/sniffer_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Sniffer adapter" do
+  before do
+    allow(Isolator).to receive(:within_transaction?) { true }
+  end
+
+  describe "#store" do
+    specify do
+      expect { Sniffer.store(Sniffer::DataItem.new) }.to raise_error(Isolator::HTTPError)
+    end
+  end
+end

--- a/spec/isolator/adapters/mailer/mailer_spec.rb
+++ b/spec/isolator/adapters/mailer/mailer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Mailer adapter" do
+  before do
+    allow(Isolator).to receive(:within_transaction?) { true }
+  end
+
+  describe "#deliver_now" do
+    specify do
+      expect { SampleEmail.hello.deliver_now }.to raise_error(Isolator::MailerError)
+    end
+  end
+
+  describe "#deliver_later" do
+    specify do
+      expect { SampleEmail.hello.deliver_later }.to raise_error(Isolator::BackgroundJobError)
+    end
+  end
+end

--- a/spec/isolator/orm_adapters/active_record_spec.rb
+++ b/spec/isolator/orm_adapters/active_record_spec.rb
@@ -6,249 +6,21 @@ describe "ActiveRecord integration" do
   let(:ar_class) { User }
 
   describe ".transaction" do
-    after { expect(Isolator).to_not be_within_transaction }
-
-    context "HTTP requests" do
-      subject do
-        ar_class.transaction do
-          Net::HTTP.get("example.com", "/index.html")
-        end
+    it do
+      expect(Isolator).to_not be_within_transaction
+      ar_class.transaction do
+        expect(Isolator).to be_within_transaction
       end
-
-      it { expect { subject }.to raise_error(Isolator::HTTPError) }
-
-      context "when adapter is disabled" do
-        around do |ex|
-          Isolator.adapters.http.disable!
-          ex.run
-          Isolator.adapters.http.enable!
-        end
-
-        it "doesn't raise" do
-          expect { subject }.to_not raise_error
-        end
-      end
-
-      context "when Isolator is disabled" do
-        around do |ex|
-          Isolator.disable!
-          ex.run
-          Isolator.enable!
-        end
-
-        it "doesn't raise" do
-          expect { subject }.to_not raise_error
-        end
-      end
-    end
-
-    context "Background Jobs" do
-      context "ActiveJob" do
-        subject do
-          ar_class.transaction do
-            ActiveJobWorker.perform_later
-          end
-        end
-
-        it { expect { subject }.to raise_error(Isolator::BackgroundJobError) }
-
-        context "when adapter is disabled" do
-          around do |ex|
-            Isolator.adapters.active_job.disable!
-            ex.run
-            Isolator.adapters.active_job.enable!
-          end
-
-          it "doesn't raise" do
-            expect { subject }.to_not raise_error
-          end
-        end
-      end
-
-      context "Sidekiq" do
-        subject do
-          ar_class.transaction do
-            SidekiqWorker.perform_async
-          end
-        end
-
-        it { expect { subject }.to raise_error(Isolator::BackgroundJobError) }
-
-        context "when adapter is disabled" do
-          around do |ex|
-            Isolator.adapters.sidekiq.disable!
-            ex.run
-            Isolator.adapters.sidekiq.enable!
-          end
-
-          it "doesn't raise" do
-            expect { subject }.to_not raise_error
-          end
-        end
-      end
-
-      context "Resque" do
-        subject do
-          ar_class.transaction do
-            Resque.enqueue(ResqueWorker)
-          end
-        end
-
-        it { expect { subject }.to raise_error(Isolator::BackgroundJobError) }
-
-        context "when adapter is disabled" do
-          around do |ex|
-            Isolator.adapters.resque.disable!
-            ex.run
-            Isolator.adapters.resque.enable!
-          end
-
-          it "doesn't raise" do
-            expect { subject }.to_not raise_error
-          end
-        end
-      end
-
-      context "Resque scheduler adapter" do
-        subject do
-          ar_class.transaction do
-            Resque.enqueue_at(1.minute.from_now, ResqueWorker)
-          end
-        end
-
-        it { expect { subject }.to raise_error(Isolator::BackgroundJobError) }
-
-        context "when adapter is disabled" do
-          around do |ex|
-            Isolator.adapters.resque_scheduler.disable!
-            ex.run
-            Isolator.adapters.resque_scheduler.enable!
-          end
-
-          it "doesn't raise" do
-            expect { subject }.to_not raise_error
-          end
-        end
-      end
-
-      context "SuckerPunch" do
-        subject do
-          ar_class.transaction do
-            SuckerPunchWorker.perform_async
-          end
-        end
-
-        it { expect { subject }.to raise_error(Isolator::BackgroundJobError) }
-
-        context "when adapter is disabled" do
-          around do |ex|
-            Isolator.adapters.sucker_punch.disable!
-            ex.run
-            Isolator.adapters.sucker_punch.enable!
-          end
-
-          it "doesn't raise" do
-            expect { subject }.to_not raise_error
-          end
-        end
-      end
-    end
-
-    context "Email sending" do
-      context "ActionMailer" do
-        let(:deliver) do
-          ar_class.transaction do
-            SampleEmail.hello.deliver_now
-          end
-        end
-
-        let(:deliver_later) do
-          ar_class.transaction do
-            SampleEmail.hello.deliver_later
-          end
-        end
-
-        let(:email_body) do
-          ar_class.transaction do
-            SampleEmail.hello.body
-          end
-        end
-
-        context "when mailer adapter is disabled" do
-          around do |ex|
-            Isolator.adapters.mailer.disable!
-            ex.run
-            Isolator.adapters.mailer.enable!
-          end
-
-          it "doesn't raise" do
-            expect { deliver }.to_not raise_error
-          end
-        end
-
-        context "when mailer adapter is enabled" do
-          around do |ex|
-            Isolator.adapters.mailer.enable!
-            ex.run
-            Isolator.adapters.mailer.disable!
-          end
-
-          context "and active_job adapter is disabled" do
-            around do |ex|
-              Isolator.adapters.active_job.disable!
-              ex.run
-              Isolator.adapters.active_job.enable!
-            end
-
-            it "does not raise error on #deliver_later" do
-              expect { deliver_later }.to_not raise_error
-            end
-          end
-
-          it "raises Isolator::ActionMailerError on email delivering" do
-            expect { deliver }.to raise_error(Isolator::MailerError)
-          end
-
-          it "does not raise error on email rendering" do
-            expect { email_body }.to_not raise_error
-          end
-        end
-      end
-
-      context "Simple email" do
-        around do |ex|
-          Isolator.adapters.mailer.enable!
-          ex.run
-          Isolator.adapters.mailer.disable!
-        end
-
-        let(:send_email) do
-          ar_class.transaction do
-            Mail.deliver do
-              to "me@me.com"
-              from "you@you.com"
-              subject "testing"
-              body "hello"
-            end
-          end
-        end
-
-        it "raises Isolator::MailerError" do
-          expect { send_email }.to raise_error(Isolator::MailerError)
-        end
-      end
+      expect(Isolator).to_not be_within_transaction
     end
   end
 
   context "other transaction methods" do
     let(:connection) { ar_class.connection }
-    subject(:make_request) { Net::HTTP.get("example.com", "/index.html") }
 
     describe "#execute" do
       specify do
         connection.execute("begin")
-        expect { make_request }.to raise_error(Isolator::HTTPError)
-
         expect(Isolator).to be_within_transaction
 
         connection.execute("commit")
@@ -259,8 +31,6 @@ describe "ActiveRecord integration" do
     describe "#begin_db_transaction" do
       specify do
         connection.begin_db_transaction
-        expect { make_request }.to raise_error(Isolator::HTTPError)
-
         expect(Isolator).to be_within_transaction
 
         connection.commit_db_transaction


### PR DESCRIPTION
Hi! 
I suppose we have some duplication in test logic, especially in `active_record_spec.rb` and it is going to increase over the time by adding new adapters.
I think all the tests for specific notifiable adapters we have in the corresponding tests files, and I added missing.
Main thing about active_record_adapter logic - is to track opened transaction, so we need to it in the unit test files.
