### PR TITLE
Add support for database_cleaner gem for transactional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+- Add support for the [database_cleaner](https://github.com/DatabaseCleaner/database_cleaner) gem. ([@Envek][])
+
 ## 0.2.2 (2018-03-28)
 
 -  [Fix [#14](https://github.com/palkan/isolator/issues/14)] Always use default value for threshold. ([@palkan][])
@@ -35,3 +37,4 @@
 [@alexshgov]: https://github.com/alexshgov
 [@TheSmartnik]: https://github.com/TheSmartnik
 [@dsalahutdinov]: https://github.com/dsalahutdinov
+[@Envek]: https://github.com/Envek

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Isolator relys on [uniform_notifier][] to send custom notifications.
 
 **NOTE:** `uniform_notifier` should be installed separately (i.e., added to Gemfile).
 
+### Transactional tests support
+
+ - Rails' baked-in [use_transactional_tests](api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html#class-ActiveRecord::FixtureSet-label-Transactional+Tests)
+ - [database_cleaner](https://github.com/DatabaseCleaner/database_cleaner) gem. Make sure that you require isolator _after_ database_cleaner.
+
 ### Supported ORMs
 
 - `ActiveRecord` >= 4.1

--- a/isolator.gemspec
+++ b/isolator.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "fakeredis"
   spec.add_development_dependency "resque-scheduler"
   spec.add_development_dependency "sucker_punch"
+  spec.add_development_dependency "database_cleaner"
 end

--- a/lib/isolator.rb
+++ b/lib/isolator.rb
@@ -112,3 +112,4 @@ require "isolator/orm_adapters"
 
 require "isolator/adapters"
 require "isolator/railtie" if defined?(Rails)
+require "isolator/database_cleaner_support" if defined?(DatabaseCleaner)

--- a/lib/isolator/database_cleaner_support.rb
+++ b/lib/isolator/database_cleaner_support.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "database_cleaner/active_record/transaction"
+
+::DatabaseCleaner::ActiveRecord::Transaction.prepend(
+  Module.new do
+    def start
+      super
+      Isolator.transactions_threshold += 1
+    end
+
+    def clean
+      Isolator.transactions_threshold -= 1
+      super
+    end
+  end
+)

--- a/spec/integrations/database_cleaner_support_spec.rb
+++ b/spec/integrations/database_cleaner_support_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Database Cleaner tests" do
+  context "Minitest" do
+    specify "tests with exceptions" do
+      output = run_minitest("database_cleaner", name: "test_raise_with_transaction")
+
+      expect(output).to include("1 runs, 0 assertions, 0 failures, 1 errors")
+    end
+
+    specify "tests with exceptions" do
+      output = run_minitest("database_cleaner", name: "test_no_transaction_no_raise")
+
+      expect(output).to include("1 runs, 1 assertions, 0 failures, 0 errors")
+    end
+  end
+
+  context "RSpec" do
+    specify "tests with exceptions" do
+      output = run_rspec("database_cleaner", tag: "offense")
+
+      expect(output).to include("1 example, 1 failure")
+    end
+
+    specify "tests with exceptions" do
+      output = run_rspec("database_cleaner", tag: "no_transaction")
+
+      expect(output).to include("1 example, 0 failures")
+    end
+  end
+end

--- a/spec/integrations/fixtures/minitest/database_cleaner_fixture.rb
+++ b/spec/integrations/fixtures/minitest/database_cleaner_fixture.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+ENV["RAILS_ENV"] = "test"
+
+$LOAD_PATH.unshift File.expand_path("../../../../lib", __dir__)
+
+require "database_cleaner"
+
+require_relative "../../../support/rails_app"
+require "rails/test_help"
+
+DatabaseCleaner.strategy = :transaction
+
+class IsolatorDatabaseCleanerTest < ActiveSupport::TestCase
+  setup do
+    DatabaseCleaner.start
+  end
+
+  teardown do
+    DatabaseCleaner.clean
+  end
+
+  def test_no_transaction_no_raise
+    ActiveJobWorker.perform_later
+    assert true
+  end
+
+  def test_raise_with_transaction
+    User.transaction do
+      ActiveJobWorker.perform_later
+    end
+
+    assert true
+  end
+end

--- a/spec/integrations/fixtures/minitest/transactional_fixture.rb
+++ b/spec/integrations/fixtures/minitest/transactional_fixture.rb
@@ -7,8 +7,6 @@ $LOAD_PATH.unshift File.expand_path("../../../../lib", __dir__)
 require_relative "../../../support/rails_app"
 require "rails/test_help"
 
-require "isolator"
-
 class IsolatorTransactionalTest < ActiveSupport::TestCase
   self.use_transactional_tests = true if respond_to?(:use_transactional_tests)
   self.use_transactional_fixtures = true if respond_to?(:use_transactional_fixtures)

--- a/spec/integrations/fixtures/rspec/database_cleaner_fixture.rb
+++ b/spec/integrations/fixtures/rspec/database_cleaner_fixture.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+ENV["RAILS_ENV"] = "test"
+
+$LOAD_PATH.unshift File.expand_path("../../../../lib", __dir__)
+
+require "database_cleaner"
+
+require_relative "../../../support/rails_app"
+require "rspec/rails"
+
+DatabaseCleaner.strategy = :transaction
+
+RSpec.configure do |config|
+  config.around do |example|
+    DatabaseCleaner.cleaning { example.run }
+  end
+end
+
+describe "database_cleaner support" do
+  it "doesn't raise when no transaction", :no_transaction do
+    expect { ActiveJobWorker.perform_later }.not_to raise_error
+  end
+
+  it "raises with transaction", :offense do
+    User.transaction do
+      ActiveJobWorker.perform_later
+    end
+    expect(true).to eq true
+  end
+end

--- a/spec/integrations/fixtures/rspec/transactional_fixture.rb
+++ b/spec/integrations/fixtures/rspec/transactional_fixture.rb
@@ -7,8 +7,6 @@ $LOAD_PATH.unshift File.expand_path("../../../../lib", __dir__)
 require_relative "../../../support/rails_app"
 require "rspec/rails"
 
-require "isolator"
-
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
 end


### PR DESCRIPTION
[database_cleaner](https://github.com/DatabaseCleaner/database_cleaner) is quite popular and frequently used to provide transactional tests instead of Rails' built-in `use_transactional_tests = true`.