### PR TITLE
Fix database_cleaner support

### DIFF
--- a/lib/isolator/database_cleaner_support.rb
+++ b/lib/isolator/database_cleaner_support.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require "database_cleaner/active_record/transaction"
-
-::DatabaseCleaner::ActiveRecord::Transaction.prepend(
-  Module.new do
+module Isolator
+  module DatabaseCleanerSupport
     def start
       super
       Isolator.transactions_threshold += 1
@@ -14,4 +12,14 @@ require "database_cleaner/active_record/transaction"
       super
     end
   end
-)
+end
+
+begin
+  require "database_cleaner/active_record/transaction"
+
+  ::DatabaseCleaner::ActiveRecord::Transaction.prepend(Isolator::DatabaseCleanerSupport)
+rescue LoadError
+  require "database_cleaner/configuration"
+
+  ::DatabaseCleaner::Configuration.prepend(Isolator::DatabaseCleanerSupport)
+end


### PR DESCRIPTION
The original implementation assumed that the `database_cleaner-active_record` gem is being used, this fixes it to support the regular `database_cleaner` gem so if only the `database_cleaner` gem is installed, it won't raise a `LoadError`.

I'm not sure if there's a straightforward way to add a test for this situation since conditionally having gems in the load path is pretty tricky. Would this change be acceptable without a test?