### PR TITLE
allow custom ignorer usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 gemfiles/*.lock
 Gemfile.local
 .rspec_status
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+- Allow custom ignorer usage. ([@iiwo][])
+- `Isolator.load_ignore_config` is deprecated in favor of `Isolator::Ignorer.prepare`. ([@iiwo][])
+
 ## 0.6.2 (2020-03-20)
 
 - Make Sniffer version requirement open-ended. ([@palkan][])
@@ -76,3 +79,4 @@
 [@Envek]: https://github.com/Envek
 [@DmitryTsepelev]: https://github.com/DmitryTsepelev
 [@shivanshgaur]: https://github.com/shivanshgaur
+[@iiwo]: https://github.com/iiwo

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Isolator.configure do |config|
   # Customize backtrace filtering (provide a callable)
   # By default, just takes the top-5 lines
   config.backtrace_filter = ->(backtrace) { backtrace.take(5) }
+
+  # Define a custom ignorer class (must implement .prepare)
+  # uses a row number based list from the .isolator_todo.yml file
+  config.ignorer = Isolator::Ignorer
 end
 ```
 
@@ -167,7 +171,7 @@ All the exceptions raised in the listed lines will be ignored.
 
 ### Using with legacy Ruby codebases
 
-If you are not using Rails, you'll have to load ignores from file manually, using `Isolator#load_ignore_config`, for instance `Isolator.load_ignore_config("./config/.isolator_todo.yml")`
+If you are not using Rails, you'll have to load ignores from file manually, using `Isolator::Ignorer.prepare(path:)`, for instance `Isolator::Ignorer.prepare(path: "./config/.isolator_todo.yml")`
 
 ## Custom Adapters
 
@@ -183,7 +187,7 @@ Suppose that you have a class `Danger` with a method `#explode`, which is not sa
 # the third one is a method name.
 Isolator.isolate :danger, Danger, :explode, options
 
-# NOTE: if you want to isolate a class method, use signleton_class instead
+# NOTE: if you want to isolate a class method, use singleton_class instead
 Isolator.isolate :danger, Danger.singleton_class, :explode, options
 ```
 
@@ -210,7 +214,7 @@ Isolator.before_isolate do
 end
 
 Isolator.after_isolate do
- # right after the transaction has been committed/rollbacked
+ # right after the transaction has been committed/rolled back
 end
 ```
 

--- a/lib/isolator.rb
+++ b/lib/isolator.rb
@@ -104,9 +104,13 @@ module Isolator
       @adapters ||= Isolator::SimpleHashie.new
     end
 
+    def load_ignore_config(path)
+      warn "[DEPRECATION] `load_ignore_config` is deprecated. Please use `Isolator::Ignorer.prepare` instead."
+      Isolator::Ignorer.prepare(path: path)
+    end
+
     include Isolator::Isolate
     include Isolator::Callbacks
-    include Isolator::Ignorer
   end
 end
 

--- a/lib/isolator/configuration.rb
+++ b/lib/isolator/configuration.rb
@@ -5,21 +5,27 @@ module Isolator
   #
   # - `raise_exceptions` - whether to raise an exception in case of offense;
   #   defaults to true in test env and false otherwise.
-  #   NOTE: env is infered from RACK_ENV and RAILS_ENV.
+  #   NOTE: env is inferred from RACK_ENV and RAILS_ENV.
   #
   # - `logger` - logger instance (nil by default)
   #
   # - `send_notifications` - whether to send notifications (through uniform_notifier);
-  #   defauls to false
+  #   defaults to false
+  #
+  # - `backtrace_filter` - define a custom backtrace filtering (provide a callable)
+  #
+  # - `ignorer` - define a custom ignorer (must implement .prepare)
+  #
   class Configuration
     attr_accessor :raise_exceptions, :logger, :send_notifications,
-      :backtrace_filter
+      :backtrace_filter, :ignorer
 
     def initialize
       @logger = nil
       @raise_exceptions = test_env?
       @send_notifications = false
       @backtrace_filter = ->(backtrace) { backtrace.take(5) }
+      @ignorer = Isolator::Ignorer
     end
 
     alias raise_exceptions? raise_exceptions

--- a/lib/isolator/railtie.rb
+++ b/lib/isolator/railtie.rb
@@ -7,7 +7,7 @@ module Isolator
       # (when all deps are likely to be loaded).
       load File.join(__dir__, "adapters.rb")
 
-      Isolator.load_ignore_config(Rails.root.join(".isolator_todo.yml"))
+      Isolator.config.ignorer&.prepare
 
       next unless Rails.env.test?
 

--- a/spec/isolator/ignorer_spec.rb
+++ b/spec/isolator/ignorer_spec.rb
@@ -33,6 +33,7 @@ describe "Ignorer" do
 
   before do
     allow(Isolator).to receive(:within_transaction?) { true }
+    allow(File).to receive(:exist?).with(TODO_PATH).and_return(true)
   end
 
   subject { ::Isolator::Danger }
@@ -42,40 +43,59 @@ describe "Ignorer" do
     expect { subject.call_unmasked(1, 2) }.to raise_error(Isolator::UnsafeOperationError)
   end
 
-  context "unmasked todos" do
-    before(:each) do
-      allow(File).to receive(:exist?).with(TODO_PATH).and_return(true)
+  shared_examples "todos filter" do
+    context "unmasked todos" do
+      before do
+        allow(YAML).to receive(:load_file).with(TODO_PATH).and_return(
+          "todo_unmasked_adapter" => ["spec/isolator/ignorer_spec.rb:59"],
+          "wrong_adapter" => ["spec/isolator/ignorer_spec.rb:62"]
+        )
 
-      allow(YAML).to receive(:load_file).with(TODO_PATH).and_return(
-        "todo_unmasked_adapter" => ["spec/isolator/ignorer_spec.rb:58"],
-        "wrong_adapter" => ["spec/isolator/ignorer_spec.rb:62"]
-      )
+        stub_const("Isolator::Ignorer::PATH", TODO_PATH)
+        prepare
+      end
 
-      Isolator.load_ignore_config(TODO_PATH)
+      it "doesn't raise when ignored" do
+        expect { subject.call_unmasked(1, 2) }.not_to raise_error
+      end
+
+      it "raise when wrong operator is ignored" do
+        expect { subject.call_unmasked(1, 2) }.to raise_error(Isolator::UnsafeOperationError)
+      end
     end
 
-    it "doesn't raise when ignored" do
-      expect { subject.call_unmasked(1, 2) }.not_to raise_error
-    end
+    context "masked todos" do
+      before do
+        allow(YAML).to receive(:load_file).with(TODO_PATH).and_return(
+          "todo_masked_adapter" => ["spec/isolator/**/*.rb"]
+        )
 
-    it "raise when wrong operator is ignored" do
-      expect { subject.call_unmasked(1, 2) }.to raise_error(Isolator::UnsafeOperationError)
+        stub_const("Isolator::Ignorer::PATH", TODO_PATH)
+        prepare
+      end
+
+      it "doesn't raise when ignored via mask" do
+        expect { subject.call_masked(1, 2) }.not_to raise_error
+      end
     end
   end
 
-  context "masked todos" do
-    before(:each) do
-      allow(File).to receive(:exist?).with(TODO_PATH).and_return(true)
+  it_behaves_like "todos filter" do
+    let(:prepare) { Isolator::Ignorer.prepare }
+  end
 
-      allow(YAML).to receive(:load_file).with(TODO_PATH).and_return(
-        "todo_masked_adapter" => ["spec/isolator/**/*.rb"]
+  # TODO: remove when load_ignore_config is deprecated
+  context "using deprecated 'load_ignore_config' interface method" do
+    before do
+      expect(Isolator).to(
+        receive(:warn).with(
+          "[DEPRECATION] `load_ignore_config` is deprecated. Please use `Isolator::Ignorer.prepare` instead."
+        )
       )
-
-      Isolator.load_ignore_config(TODO_PATH)
     end
 
-    it "doesn't raise when ignored via mask" do
-      expect { subject.call_masked(1, 2) }.not_to raise_error
+    it_behaves_like "todos filter" do
+      let(:prepare) { Isolator.load_ignore_config(TODO_PATH) }
     end
   end
 end


### PR DESCRIPTION
## What

enable the use of custom Ignorer by exposing a config option

## Why
Current Ignorer uses a hardcoded, row number based regex matcher. 

In an often changing codebase, this makes it difficult to work with since the numbers are always shifting (and "todo" is usually something we want to postpone 😄 ).

People should be able to replace it with custom implementation easily to better match their needs (eg. in my case method name matching rather than row numbers)