### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Isolator relies on [uniform_notifier][] to send custom notifications.
 
 ### Transactional tests support
 
- - Rails' baked-in [use_transactional_tests](api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html#class-ActiveRecord::FixtureSet-label-Transactional+Tests)
+ - Rails' baked-in [use_transactional_tests](https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html#class-ActiveRecord::FixtureSet-label-Transactional+Tests)
  - [database_cleaner](https://github.com/DatabaseCleaner/database_cleaner) gem. Make sure that you require isolator _after_ database_cleaner.
 
 ### Supported ORMs


### PR DESCRIPTION
Excluding the scheme in the url makes this try to link relative to the repo, and directs to a broken path.

