### PR TITLE
Raise a more clear error when the file does not parse to a hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Raise an error when an ignore file does not parse to a hash. ([@bobbymcwho][])
+
 ## 0.8.0 (2021-12-29)
 
 - Drop Ruby 2.5 support.
@@ -99,3 +101,4 @@ This, for example, makes Isolator compatible with Rails multi-database apps.
 [@shivanshgaur]: https://github.com/shivanshgaur
 [@iiwo]: https://github.com/iiwo
 [@mquan]: https://github.com/mquan
+[@bobbymcwho]: https://github.com/bobbymcwho

--- a/lib/isolator/railtie.rb
+++ b/lib/isolator/railtie.rb
@@ -15,7 +15,7 @@ module Isolator
       # (when all deps are likely to be loaded).
       load File.join(__dir__, "adapters.rb")
 
-      Isolator.config.ignorer&.prepare
+      Isolator.config.ignorer&.prepare(path: ".isolator_todo.yml")
       Isolator.config.ignorer&.prepare(path: ".isolator_ignore.yml")
 
       next unless Rails.env.test?

--- a/spec/isolator/ignorer_spec.rb
+++ b/spec/isolator/ignorer_spec.rb
@@ -83,12 +83,12 @@ describe "Ignorer" do
     let(:prepare) { Isolator::Ignorer.prepare(path: todo_path) }
   end
 
-  context 'when the file is not parsed to a hash' do
+  context "when the file is not parsed to a hash" do
     before do
       allow(YAML).to receive(:load_file).with(todo_path).and_return(nil)
     end
 
-    it 'raises an error' do
+    it "raises an error" do
       expect { Isolator::Ignorer.prepare(path: todo_path) }.to raise_error(
         Isolator::Ignorer::ParseError, "Unable to parse ignore config file #{todo_path}. Expected Hash, got NilClass."
       )


### PR DESCRIPTION

## What is the purpose of this pull request?  
I was running into some confusing errors when my `.isolator_todo.yml` was malformed. This PR adds a clear error and message to let the user know what is wrong.

## What changes did you make? (overview)  
I removed the constant TODO_PATH, and instead changed to explicitly pass the path to the prepare method.
I added a clear error and message that is raised when the file does not parse to a Hash. 

## Is there anything you'd like reviewers to focus on?
Happy to revert the constant removal if you'd prefer. 

## Checklist

- [X] I've added tests for this change
- [X] I've added a Changelog entry
- [ ] I've updated a documentation
