### PR TITLE
Log all filtered lines to the logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 - Raise an error when an ignore file does not parse to a hash. ([@bobbymcwho][])
+- Log all filtered backtrace lines to the logger ([@bobbymcwho][])
 
 ## 0.8.0 (2021-12-29)
 

--- a/lib/isolator/notifier.rb
+++ b/lib/isolator/notifier.rb
@@ -29,12 +29,12 @@ module Isolator
     def log_exception
       return unless Isolator.config.logger
 
-      offense_line = filtered_backtrace.first
-
       msg = "[ISOLATOR EXCEPTION]\n" \
             "#{exception.message}"
 
-      msg += "\n  ↳ #{offense_line}" if offense_line
+      filtered_backtrace.each do |offense_line|
+        msg += "\n  ↳ #{offense_line}"
+      end
 
       Isolator.config.logger.warn(msg)
     end


### PR DESCRIPTION
## What is the purpose of this pull request?
Log all filtered backtrace lines to the logger.

I considered making the # of lines to log configurable, but thought that since filtering exists, that should be enough. 

## Checklist

- [X] I've added tests for this change
- [X] I've added a Changelog entry
- [ ] I've updated a documentation
