### PR TITLE
Add support for Ruby 3 keyword arguments + add method to remove adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Raise an error when an ignore file does not parse to a hash. ([@bobbymcwho][])
 - Log all filtered backtrace lines to the logger ([@bobbymcwho][])
+- Add support for removing dynamic adapters. ([@Mange][])
 
 ## 0.8.0 (2021-12-29)
 
@@ -103,3 +104,4 @@ This, for example, makes Isolator compatible with Rails multi-database apps.
 [@iiwo]: https://github.com/iiwo
 [@mquan]: https://github.com/mquan
 [@bobbymcwho]: https://github.com/bobbymcwho
+[@Mange]: https://github.com/Mange

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- Support keyword arguments to isolated method in Ruby 3.0. ([@Mange][])
 - Raise an error when an ignore file does not parse to a hash. ([@bobbymcwho][])
 - Log all filtered backtrace lines to the logger ([@bobbymcwho][])
 - Add support for removing dynamic adapters. ([@Mange][])

--- a/README.md
+++ b/README.md
@@ -220,6 +220,23 @@ Isolator.isolate :promoter,
   }
 ```
 
+Trying to register the same adapter name twice will raise an error. You can guard for it, or remove old adapters before in order to replace them.
+
+```ruby
+unless Isolator.has_adapter?(:promoter)
+  Isolator.isolate(:promoter, *rest)
+end
+```
+
+```ruby
+# Handle code reloading
+class Messager
+end
+
+Isolator.remove_adapter(:messager)
+Isolator.isolate(:messager, target: Messager, *rest)
+```
+
 You can also add some callbacks to be run before and after the transaction:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -205,8 +205,18 @@ Isolator.isolate :active_job,
   target: ActiveJob::Base,
   method_name: :enqueue,
   exception_class: Isolator::BackgroundJobError,
-  details_message: ->(obj, _args) {
+  details_message: ->(obj) {
     "#{obj.class.name}(#{obj.arguments})"
+  }
+
+Isolator.isolate :promoter,
+  target: UserPromoter,
+  method_name: :call,
+  details_message: ->(obj_, args, kwargs) {
+    # UserPromoter.call(user, role, by: nil)
+    user, role = args
+    by = kwargs[:by]
+    "#{user.name} promoted to #{role} by #{by&.name || "system"})"
   }
 ```
 

--- a/lib/isolator.rb
+++ b/lib/isolator.rb
@@ -174,6 +174,10 @@ module Isolator
       @adapters ||= Isolator::SimpleHashie.new
     end
 
+    def has_adapter?(id)
+      adapters.key?(id.to_s)
+    end
+
     def load_ignore_config(path)
       warn "[DEPRECATION] `load_ignore_config` is deprecated. Please use `Isolator::Ignorer.prepare` instead."
       Isolator::Ignorer.prepare(path: path)

--- a/lib/isolator/adapter_builder.rb
+++ b/lib/isolator/adapter_builder.rb
@@ -32,9 +32,9 @@ module Isolator
         return nil unless method_name
 
         Module.new do
-          define_method method_name do |*args, &block|
-            adapter.notify(caller, self, *args)
-            super(*args, &block)
+          define_method method_name do |*args, **kwargs, &block|
+            adapter.notify(caller, self, *args, **kwargs)
+            super(*args, **kwargs, &block)
           end
         end
       end

--- a/lib/isolator/adapter_builder.rb
+++ b/lib/isolator/adapter_builder.rb
@@ -5,29 +5,39 @@ require "isolator/adapters/base"
 module Isolator
   # Builds adapter from provided params
   module AdapterBuilder
-    def self.call(target: nil, method_name: nil, **options)
-      adapter = Module.new do
-        extend Isolator::Adapters::Base
+    class << self
+      def call(target: nil, method_name: nil, **options)
+        adapter = Module.new do
+          extend Isolator::Adapters::Base
 
-        self.exception_class = options[:exception_class] if options.key?(:exception_class)
-        self.exception_message = options[:exception_message] if options.key?(:exception_message)
-        self.details_message = options[:details_message] if options.key?(:details_message)
+          self.exception_class = options[:exception_class] if options.key?(:exception_class)
+          self.exception_message = options[:exception_message] if options.key?(:exception_message)
+          self.details_message = options[:details_message] if options.key?(:details_message)
+        end
+
+        mod = build_mod(method_name, adapter)
+        if target && mod
+          target.prepend(mod)
+          adapter.define_singleton_method(:restore) do
+            mod.remove_method(method_name)
+          end
+        end
+
+        adapter
       end
 
-      add_patch_method(adapter, target, method_name) if
-        target && method_name
-      adapter
-    end
+      private
 
-    def self.add_patch_method(adapter, base, method_name)
-      mod = Module.new do
-        define_method method_name do |*args, &block|
-          adapter.notify(caller, self, *args)
-          super(*args, &block)
+      def build_mod(method_name, adapter)
+        return nil unless method_name
+
+        Module.new do
+          define_method method_name do |*args, &block|
+            adapter.notify(caller, self, *args)
+            super(*args, &block)
+          end
         end
       end
-
-      base.prepend mod
     end
   end
 end

--- a/lib/isolator/adapters/background_jobs/active_job.rb
+++ b/lib/isolator/adapters/background_jobs/active_job.rb
@@ -4,7 +4,7 @@ Isolator.isolate :active_job,
   target: ActiveJob::Base,
   method_name: :enqueue,
   exception_class: Isolator::BackgroundJobError,
-  details_message: ->(obj, _args) {
+  details_message: ->(obj) {
     "#{obj.class.name}" \
     "#{obj.arguments.any? ? " (#{obj.arguments.join(", ")})" : ""}"
   }

--- a/lib/isolator/adapters/base.rb
+++ b/lib/isolator/adapters/base.rb
@@ -22,13 +22,13 @@ module Isolator
         @disabled == true
       end
 
-      def notify(backtrace, obj, *args)
-        return unless notify?(*args)
-        Isolator.notify(exception: build_exception(obj, args), backtrace: backtrace)
+      def notify(backtrace, obj, *args, **kwargs)
+        return unless notify?(*args, **kwargs)
+        Isolator.notify(exception: build_exception(obj, args, kwargs), backtrace: backtrace)
       end
 
-      def notify?(*args)
-        enabled? && Isolator.enabled? && Isolator.within_transaction? && !ignored?(*args)
+      def notify?(*args, **kwargs)
+        enabled? && Isolator.enabled? && Isolator.within_transaction? && !ignored?(*args, **kwargs)
       end
 
       def ignore_if(&block)
@@ -39,16 +39,35 @@ module Isolator
         @ignores ||= []
       end
 
-      def ignored?(*args)
-        ignores.any? { |block| block.call(*args) }
+      def ignored?(*args, **kwargs)
+        ignores.any? { |block| block.call(*args, **kwargs) }
       end
 
       private
 
-      def build_exception(obj, args)
+      def build_exception(obj, args, kwargs = {})
         klass = exception_class || Isolator::UnsafeOperationError
-        details = details_message.call(obj, args) if details_message
+        details = build_details(obj, args, kwargs)
         klass.new(exception_message, details: details)
+      end
+
+      def build_details(obj, args, kwargs)
+        return nil unless details_message
+
+        case details_message.arity
+        when 2, -2
+          # Older users of details_message expected only two arguments. Add
+          # kwargs hash as last argument, like in older Ruby.
+          details_message.call(obj, args + [kwargs])
+        when 3, -3
+          # New signature separates args from kwargs
+          details_message.call(obj, args, kwargs)
+        when 1
+          # Callback does not care about any args
+          details_message.call(obj)
+        else
+          raise "Unexpected arity (#{details_message.arity}) for #{details_message.inspect}"
+        end
       end
     end
   end

--- a/lib/isolator/adapters/http/webmock.rb
+++ b/lib/isolator/adapters/http/webmock.rb
@@ -2,7 +2,7 @@
 
 adapter = Isolator.isolate :webmock,
   exception_class: Isolator::HTTPError,
-  details_message: ->(obj, _args) {
+  details_message: ->(obj) {
                      "#{obj.method.to_s.upcase} #{obj.uri}"
                    }
 

--- a/lib/isolator/adapters/mailers/mail.rb
+++ b/lib/isolator/adapters/mailers/mail.rb
@@ -3,7 +3,7 @@
 Isolator.isolate :mailer, target: Mail::Message,
                           method_name: :deliver,
                           exception_class: Isolator::MailerError,
-                          details_message: ->(obj, _args) {
+                          details_message: ->(obj) {
                             "From: #{obj.from}\n" \
                             "To: #{obj.to}\n" \
                             "Subject: #{obj.subject}"

--- a/lib/isolator/isolate.rb
+++ b/lib/isolator/isolate.rb
@@ -4,9 +4,15 @@ module Isolator
   # Add .isolate function to build and register adapters
   module Isolate
     def isolate(id, **options)
-      raise "Adapter already registered: #{id}" if Isolator.adapters.key?(id.to_s)
+      raise "Adapter already registered: #{id}" if Isolator.has_adapter?(id)
       adapter = AdapterBuilder.call(**options)
       Isolator.adapters[id.to_s] = adapter
+    end
+
+    def remove_adapter(id)
+      if (adapter = Isolator.adapters.delete(id.to_s))
+        adapter.restore if adapter.respond_to?(:restore)
+      end
     end
   end
 end

--- a/spec/isolator/dynamic_adapters_spec.rb
+++ b/spec/isolator/dynamic_adapters_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe Isolator, "dynamic adapters" do
       def test
         42
       end
+
+      def sum(a, b)
+        a + b
+      end
+
+      def round(num, precision: 0)
+        num.round(precision)
+      end
+
+      def shout
+        yield.upcase
+      end
     }
   end
 
@@ -58,5 +70,23 @@ RSpec.describe Isolator, "dynamic adapters" do
     expect {
       Isolator.remove_adapter(:foo)
     }.not_to raise_error
+  end
+
+  it "supports arguments in the modified method" do
+    Isolator.isolate(:foo, target: example_class, method_name: :sum)
+    expect(example_class.new.sum(10, 25)).to eq(35)
+  end
+
+  it "supports keyword arguments in the modified method" do
+    Isolator.isolate(:foo, target: example_class, method_name: :round)
+
+    expect(example_class.new.round(0.05)).to eq(0)
+    expect(example_class.new.round(0.05, precision: 1)).to eq(0.1)
+  end
+
+  it "supports blocks in the modified method" do
+    Isolator.isolate(:foo, target: example_class, method_name: :shout)
+
+    expect(example_class.new.shout { "hello" }).to eq("HELLO")
   end
 end

--- a/spec/isolator/dynamic_adapters_spec.rb
+++ b/spec/isolator/dynamic_adapters_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Isolator, "dynamic adapters" do
+  let(:example_class) do
+    Class.new {
+      def test
+        42
+      end
+    }
+  end
+
+  before do
+    Isolator.remove_adapter(:foo)
+  end
+
+  def within_transaction
+    Isolator.incr_transactions!
+    yield
+  ensure
+    Isolator.decr_transactions!
+  end
+
+  it "checks that the specified method is not called inside a transaction" do
+    expect(Isolator.has_adapter?(:foo)).to eq(false)
+    Isolator.isolate(:foo, target: example_class, method_name: :test)
+
+    expect(Isolator.has_adapter?(:foo)).to eq(true)
+    expect(example_class.new.test).to eq(42)
+
+    within_transaction do
+      expect {
+        example_class.new.test
+      }.to raise_error(Isolator::UnsafeOperationError)
+    end
+  end
+
+  it "restores original method when removed" do
+    Isolator.isolate(:foo, target: example_class, method_name: :test)
+
+    within_transaction do
+      expect {
+        example_class.new.test
+      }.to raise_error(Isolator::UnsafeOperationError)
+    end
+
+    Isolator.remove_adapter(:foo)
+
+    within_transaction do
+      expect {
+        example_class.new.test
+      }.not_to raise_error
+    end
+  end
+
+  it "does nothing when removing non-existing adapter" do
+    expect {
+      Isolator.remove_adapter(:foo)
+    }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## What is the purpose of this pull request?

This fixes two bugs I've been having in my project using this.

### Removing adapters

The first bug is that code reloading in Rails causes double registration of adapters. Code reloading could be disabled by including the class earlier and/or making the adapter only register once at startup, but then things fail in development while making changes to the class.

My current workaround was to manually access the `Isolator.adapters` array and removing the entry before calling `Isolator.isolate`.

### Ruby 3 keyword arguments

The second bug came up when upgrading to Ruby 3, as one of my classes that are isolated uses keyword arguments. In Ruby 3 a method like `def x(*args)` will no longer accept keyword arguments, and the modded method uses a construct like that to catch arguments.

## What changes did you make?

I added the following methods:

- `Isolator.has_adapter?` - to check if an adapter is there or not. Uses same key normalization logic as `isolate`.
- `Isolator.remove_adapter` - to remove an adapter and restore the modded class.

I changed some tests:

- Added BDD-like tests for dynamic isolation of custom classes to explain the feature some more.
- Reworked some isolation tests to rely on less global state in the form of mystery guests.

I changed some behavior:

- The `details_message` callback does not require arguments to be accepted anymore, taking only `(object)`.
- If `details_message` accepts three arguments, then it gets `(object, args, kwargs)`.
- For existing codebases where `details_message` accepts exactly 2 arguments, it will get `(object, args + [kwargs])` to be backwards compatible.
- Removed `Isolator.add_patch_method` and added a similar private class method instead. I don't think it was intended to be public.

## Is there anything you'd like reviewers to focus on?

### Restoring logic

Restoring the mod is very difficult since you cannot remove an included/prepended module in Ruby. The closest I could do was to remove the method on the dynamically-generated module so it becomes an empty method that doesn't do anything.
That means that there's no clean restoration, and by checking the ancestor chain you could tell a class was isolated before. If you keep adding and removing isolation on a class it will keep getting more and more empty modules in its inheritance chain.
I regarded this as a small problem, and I suspect that the most common case is for code reloading in development, at which point the classes will also be recreated each time and having heir ancestor chains cleared implicitly.

Please verify this assumption.

### Testing structure

The tests I added follow RSpec/BDD style, which most other tests do not. I was very unsure about the style the tests are supposed to be written in. Please let me know if you want them structured differently.

### Placement of `has_adapter?` and `remove_adapter`

I placed `remove_adapter` close to `isolate` since they are a pair, but `has_adapter?` next to the `adapter` definition. I'm not sure why `isolate` is defined in its own module, so I might be placing things in the wrong place.

Is this a good place to have the new methods?

### Removal of `Isolator.add_patch_method`

I don't think this was intended to be a public method. Was it a mistake to remove it?

### Bigger PR

Should I split this PR into two smaller ones instead? I joined this up because it followed naturally for me (in order to fix the kwargs issue, I needed tests, and in order to make isolated tests I needed to be able to restore things, etc.).

I'll use my own fork to get my project moving again for now, but if you want two different PRs I will close this and create new branches with more focused changes  and open them in series instead.

## Checklist

- [X] I've added tests for this change
- [X] I've added a Changelog entry
- [X] I've updated a documentation
