### PR TITLE
make spec descriptions in sidekiq_spec match spec subjects

### DIFF
--- a/spec/isolator/adapters/background_jobs/sidekiq_spec.rb
+++ b/spec/isolator/adapters/background_jobs/sidekiq_spec.rb
@@ -9,13 +9,13 @@ describe "Sidekiq adapter" do
 
   let(:worker) { SidekiqWorker }
 
-  describe "#perform_now" do
+  describe "#perform_async" do
     specify do
       expect { worker.perform_async }.to raise_error(Isolator::BackgroundJobError)
     end
   end
 
-  describe "#perform_later" do
+  describe "#perform_at" do
     specify do
       expect { worker.perform_at(3.days.from_now) }.to raise_error(Isolator::BackgroundJobError, /SidekiqWorker/)
     end


### PR DESCRIPTION
## What is the purpose of this pull request?

This prevents misreading the spec (as I did in #52 for example - though
this doesn't actually fix that issue).