### PR TITLE
Adds Ruby 3.2 to the build, upgrades actions, and simplifies bundling.

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -10,9 +10,8 @@ jobs:
   rspec:
     runs-on: ubuntu-latest
     env:
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
       CI: true
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,24 +31,14 @@ jobs:
         - ruby: "3.1"
           gemfile: "gemfiles/railsmaster.gemfile"
           bundler: "2"
+        - ruby: "3.2"
+          gemfile: "gemfiles/railsmaster.gemfile"
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      with:
-        path: /home/runner/bundle
-        key: bundle-${{ matrix.ruby }}-${{ matrix.gemfile }}-${{ hashFiles(matrix.gemfile) }}-${{ hashFiles('**/*.gemspec') }}
-        restore-keys: |
-          bundle-${{ matrix.ruby }}-${{ matrix.gemfile }}-
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: ${{ matrix.bundler }}
-    - name: Bundle install
-      run: |
-        bundle config path /home/runner/bundle
-        bundle config --global gemfile ${{ matrix.gemfile }}
-        bundle install
-        bundle update
+        bundler-cache: true
     - name: Run RSpec
       run: |
         bundle exec rspec

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,13 +9,14 @@ on:
 jobs:
   rubocop:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/rubocop.gemfile
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
+        bundler-cache: true
     - name: Lint Ruby code with RuboCop
       run: |
-        gem install bundler
-        bundle install --gemfile gemfiles/rubocop.gemfile --jobs 4 --retry 3
-        bundle exec --gemfile gemfiles/rubocop.gemfile rubocop
+        bundle exec rubocop


### PR DESCRIPTION
## What is the purpose of this pull request?

Add Ruby 3.2 to CI, so that the gem is tested with Ruby 3.2

## What changes did you make? (overview)

Adds Ruby 3.2 to the CI build.
Updates the checkout action version
Switched the bundling and caching to built-in capabilities

## Is there anything you'd like reviewers to focus on?

I think the changes are straightforward.

## Checklist

# - [ ] I've added tests for this change (Not applicable)
- [ ] I've added a Changelog entry 
- [ ] I've updated a documentation
