### PR TITLE
Allow aliases in .isolator_todo.yml and .isolator_ignore.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Raise an error when an ignore file does not parse to a hash. ([@bobbymcwho][])
 - Log all filtered backtrace lines to the logger ([@bobbymcwho][])
 - Add support for removing dynamic adapters. ([@Mange][])
+- Allow aliases in .isolator_todo.yml and .isolator_ignore.yml ([@tomgi][])
 
 ## 0.8.0 (2021-12-29)
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ sidekiq:
 You can ignore the same files in multiple adapters using YML aliases in the following way:
 
 ```
-common_http: &common_http
+http_common: &http_common
   - app/models/user.rb:20
 
 http: *http_common

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ You can add as many _ignores_ as you want, the offense is registered iff all of 
 
 ### Using with sidekiq/testing
 
-If you require sidekiq/testing in your tests after isolator is required then it will blow away isolator's hooks, so you need to require isolator after requiring sidekiq/testing. 
+If you require sidekiq/testing in your tests after isolator is required then it will blow away isolator's hooks, so you need to require isolator after requiring sidekiq/testing.
 
 If you're using Rails and want to use isolator in development and staging, then here is a way to do this.
 
@@ -190,6 +190,16 @@ If you already have a huge Rails project it can be tricky to turn Isolator on be
 sidekiq:
   - app/models/user.rb:20
   - app/models/sales/**/*.rb
+```
+
+You can ignore the same files in multiple adapters using YML aliases in the following way:
+
+```
+common_http: &common_http
+  - app/models/user.rb:20
+
+http: *http_common
+webmock: *http_common
 ```
 
 All the exceptions raised in the listed lines will be ignored.

--- a/lib/isolator/ignorer.rb
+++ b/lib/isolator/ignorer.rb
@@ -18,7 +18,12 @@ module Isolator
       def prepare(path:, regex_string: "^.*(#ignores#):.*$")
         return unless File.exist?(path)
 
-        ignores = YAML.load_file(path, aliases: true)
+        ignores = begin
+          YAML.load_file(path, aliases: true)
+        rescue ArgumentError # support for older rubies https://github.com/rails/rails/commit/179d0a1f474ada02e0030ac3bd062fc653765dbe
+          YAML.load_file(path)
+        end
+
         raise ParseError.new(path, ignores.class) unless ignores.respond_to?(:fetch)
 
         Isolator.adapters.each do |id, adapter|

--- a/lib/isolator/ignorer.rb
+++ b/lib/isolator/ignorer.rb
@@ -18,7 +18,7 @@ module Isolator
       def prepare(path:, regex_string: "^.*(#ignores#):.*$")
         return unless File.exist?(path)
 
-        ignores = YAML.load_file(path)
+        ignores = YAML.load_file(path, aliases: true)
         raise ParseError.new(path, ignores.class) unless ignores.respond_to?(:fetch)
 
         Isolator.adapters.each do |id, adapter|

--- a/spec/isolator/ignorer_spec.rb
+++ b/spec/isolator/ignorer_spec.rb
@@ -3,78 +3,102 @@
 require "spec_helper"
 
 describe "Ignorer" do
-  let(:todo_path) { ".isolator_todo.yml" }
+  let(:todo_temp_file) { Tempfile.new('.isolator_todo.yml') }
+  let(:todo_path) { todo_temp_file.path }
 
-  before(:all) do
+  before(:each) do
     module ::Isolator::Danger # rubocop:disable Lint/ConstantDefinitionInBlock
-      def self.call_masked(a, b)
+      def self.call_foo(a, b)
         a + b
       end
 
-      def self.call_unmasked(a, b)
+      def self.call_bar(a, b)
         a + b
       end
     end
 
-    Isolator.isolate :todo_masked_adapter,
+    Isolator.isolate :todo_foo_adapter,
       target: ::Isolator::Danger.singleton_class,
-      method_name: :call_masked
+      method_name: :call_foo
 
-    Isolator.isolate :todo_unmasked_adapter,
+    Isolator.isolate :todo_bar_adapter,
       target: ::Isolator::Danger.singleton_class,
-      method_name: :call_unmasked
+      method_name: :call_bar
   end
 
-  after(:all) do
+  after(:each) do
     Isolator.send(:remove_const, "Danger")
-    Isolator.adapters.delete("todo_masked_adapter")
-    Isolator.adapters.delete("todo_unmasked_adapter")
+    Isolator.adapters.delete("todo_foo_adapter")
+    Isolator.adapters.delete("todo_bar_adapter")
   end
 
   before do
     allow(Isolator).to receive(:within_transaction?) { true }
-    allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:exist?).with(todo_path).and_return(true)
   end
 
   subject { ::Isolator::Danger }
 
   specify do
-    expect { subject.call_masked(1, 2) }.to raise_error(Isolator::UnsafeOperationError)
-    expect { subject.call_unmasked(1, 2) }.to raise_error(Isolator::UnsafeOperationError)
+    expect { subject.call_foo(1, 2) }.to raise_error(Isolator::UnsafeOperationError)
+    expect { subject.call_bar(1, 2) }.to raise_error(Isolator::UnsafeOperationError)
   end
 
   shared_examples "todos filter" do
-    context "unmasked todos" do
+    context "exact files paths todos" do
       before do
-        allow(YAML).to receive(:load_file).with(todo_path).and_return(
-          "todo_unmasked_adapter" => ["spec/isolator/ignorer_spec.rb:59"],
-          "wrong_adapter" => ["spec/isolator/ignorer_spec.rb:62"]
-        )
+        todo_temp_file.write(%{
+          todo_foo_adapter:
+            - spec/isolator/ignorer_spec.rb:61
+          wrong_adapter:
+            - spec/isolator/ignorer_spec.rb:65
+        })
+        todo_temp_file.close
 
         prepare
       end
 
       it "doesn't raise when ignored" do
-        expect { subject.call_unmasked(1, 2) }.not_to raise_error
+        expect { subject.call_foo(1, 2) }.not_to raise_error
       end
 
       it "raise when wrong operator is ignored" do
-        expect { subject.call_unmasked(1, 2) }.to raise_error(Isolator::UnsafeOperationError)
+        expect { subject.call_bar(1, 2) }.to raise_error(Isolator::UnsafeOperationError)
       end
     end
 
-    context "masked todos" do
+    context "wildcard glob pattern todos" do
       before do
-        allow(YAML).to receive(:load_file).with(todo_path).and_return(
-          "todo_masked_adapter" => ["spec/isolator/**/*.rb"]
-        )
+        todo_temp_file.write(%{
+          todo_foo_adapter:
+            - spec/isolator/**/*.rb
+        })
+        todo_temp_file.close
 
         prepare
       end
 
-      it "doesn't raise when ignored via mask" do
-        expect { subject.call_masked(1, 2) }.not_to raise_error
+      it "doesn't raise when ignored" do
+        expect { subject.call_foo(1, 2) }.not_to raise_error
+      end
+    end
+
+    context "common yml alias reused in multiple adapters in todos" do
+      before do
+        todo_temp_file.write(%{
+          common: &common
+            - spec/isolator/**/*.rb
+
+          todo_foo_adapter: *common
+          todo_bar_adapter: *common
+        })
+        todo_temp_file.close
+
+        prepare
+      end
+
+      it "doesn't raise when ignored", :aggregate_failures do
+        expect { subject.call_foo(1, 2) }.not_to raise_error
+        expect { subject.call_bar(1, 2) }.not_to raise_error
       end
     end
   end
@@ -85,7 +109,7 @@ describe "Ignorer" do
 
   context "when the file is not parsed to a hash" do
     before do
-      allow(YAML).to receive(:load_file).with(todo_path).and_return(nil)
+      todo_temp_file.close
     end
 
     it "raises an error" do

--- a/spec/isolator/ignorer_spec.rb
+++ b/spec/isolator/ignorer_spec.rb
@@ -114,7 +114,7 @@ describe "Ignorer" do
 
     it "raises an error" do
       expect { Isolator::Ignorer.prepare(path: todo_path) }.to raise_error(
-        Isolator::Ignorer::ParseError, "Unable to parse ignore config file #{todo_path}. Expected Hash, got NilClass."
+        Isolator::Ignorer::ParseError, /Unable to parse ignore config file #{todo_path}. Expected Hash, got (NilClass|FalseClass)./
       )
     end
   end

--- a/spec/isolator/ignorer_spec.rb
+++ b/spec/isolator/ignorer_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "Ignorer" do
-  let(:todo_temp_file) { Tempfile.new('.isolator_todo.yml') }
+  let(:todo_temp_file) { Tempfile.new(".isolator_todo.yml") }
   let(:todo_path) { todo_temp_file.path }
 
   before(:each) do
@@ -46,12 +46,12 @@ describe "Ignorer" do
   shared_examples "todos filter" do
     context "exact files paths todos" do
       before do
-        todo_temp_file.write(%{
+        todo_temp_file.write(%(
           todo_foo_adapter:
             - spec/isolator/ignorer_spec.rb:61
           wrong_adapter:
             - spec/isolator/ignorer_spec.rb:65
-        })
+        ))
         todo_temp_file.close
 
         prepare
@@ -68,10 +68,10 @@ describe "Ignorer" do
 
     context "wildcard glob pattern todos" do
       before do
-        todo_temp_file.write(%{
+        todo_temp_file.write(%(
           todo_foo_adapter:
             - spec/isolator/**/*.rb
-        })
+        ))
         todo_temp_file.close
 
         prepare
@@ -84,13 +84,13 @@ describe "Ignorer" do
 
     context "common yml alias reused in multiple adapters in todos" do
       before do
-        todo_temp_file.write(%{
+        todo_temp_file.write(%(
           common: &common
             - spec/isolator/**/*.rb
 
           todo_foo_adapter: *common
           todo_bar_adapter: *common
-        })
+        ))
         todo_temp_file.close
 
         prepare


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Allow todo and ignore YML files to contain aliases, e.g.

```
http_common: &http_common
  - app/some_file.rb:123
  - app/another_file.rb:456

http: *http_common
webmock: *http_common
```

This can be especially useful to share the same ignore/todo list for http and webmock adapters. 

## What changes did you make? (overview)

Pass `aliases: true` to `YAML.load_file`. Otherwise the following exception is raised when the file contains aliases:

```
Psych::AliasesNotEnabled:
       Alias parsing was not enabled.
```

## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
