### PR TITLE
Use transaction.active_record event if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Use Rails new `transaction.active_record` event if available to better handle edge cases. ([@palkan][])
+
 - Fix logging non-UTF8 strings. ([@palkan][])
 
   Fixes [#66](https://github.com/palkan/isolator/issues/66)

--- a/lib/isolator/orm_adapters/active_record.rb
+++ b/lib/isolator/orm_adapters/active_record.rb
@@ -2,4 +2,10 @@
 
 require_relative "./active_support_subscriber"
 
-Isolator::ActiveSupportSubscriber.subscribe!("sql.active_record")
+# We rely on this feature introduced in 7.1.0.beta1: https://github.com/rails/rails/pull/49192
+if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+  require_relative "./active_support_transaction_subscriber"
+  Isolator::ActiveSupportTransactionSubscriber.subscribe!
+else
+  Isolator::ActiveSupportSubscriber.subscribe!("sql.active_record")
+end

--- a/lib/isolator/orm_adapters/active_support_subscriber.rb
+++ b/lib/isolator/orm_adapters/active_support_subscriber.rb
@@ -7,14 +7,46 @@ module Isolator
     START_PATTERN = %r{(\ABEGIN|\ASAVEPOINT)}xi
     FINISH_PATTERN = %r{(\ACOMMIT|\AROLLBACK|\ARELEASE|\AEND TRANSACTION)}xi
 
-    def self.subscribe!(event)
-      ::ActiveSupport::Notifications.subscribe(event) do |_name, _start, _finish, _id, query|
-        connection_id = query[:connection_id] || query[:connection]&.object_id || 0
-        # Prevents "ArgumentError: invalid byte sequence in UTF-8" by replacing invalid byte sequence with "?"
-        sanitized_query = query[:sql].encode("UTF-8", "binary", invalid: :replace, undef: :replace, replace: "?")
-        Isolator.incr_transactions!(connection_id) if START_PATTERN.match?(sanitized_query)
-        Isolator.decr_transactions!(connection_id) if FINISH_PATTERN.match?(sanitized_query)
+    class Subscriber
+      def start(event, id, payload)
+        return unless start_event?(payload[:sql])
+
+        connection_id = extract_connection_id(payload)
+
+        Isolator.incr_transactions!(connection_id)
       end
+
+      def finish(event, id, payload)
+        return unless finish_event?(payload[:sql])
+
+        connection_id = extract_connection_id(payload)
+
+        Isolator.decr_transactions!(connection_id)
+      end
+
+      private
+
+      def start_event?(sql)
+        START_PATTERN.match?(sanitize_query(sql))
+      end
+
+      def finish_event?(sql)
+        FINISH_PATTERN.match?(sanitize_query(sql))
+      end
+
+      # Prevents "ArgumentError: invalid byte sequence in UTF-8" by replacing invalid byte sequence with "?"
+      def sanitize_query(sql)
+        sql.encode("UTF-8", "binary", invalid: :replace, undef: :replace, replace: "?")
+      end
+
+      def extract_connection_id(payload)
+        payload[:connection_id] || payload[:connection]&.object_id || 0
+      end
+    end
+
+    def self.subscribe!(event)
+      subscriber = Subscriber.new
+      ::ActiveSupport::Notifications.subscribe(event, subscriber)
     end
   end
 end

--- a/lib/isolator/orm_adapters/active_support_transaction_subscriber.rb
+++ b/lib/isolator/orm_adapters/active_support_transaction_subscriber.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Isolator
+  # ActiveSupport notifications subscriber for "transaction.active_record" event (new in Rails 7.1)
+  module ActiveSupportTransactionSubscriber
+    class Subscriber < ActiveSupportSubscriber::Subscriber
+      attr_reader :stacks
+
+      def initialize
+        @stacks = Hash.new { |h, k| h[k] = [] }
+      end
+
+      def start(event, id, payload)
+        if event.start_with?("transaction.")
+          connection_id = extract_transaction_connection_id(payload)
+
+          # transaction.active_record can be issued without a query (when we restart the transaction),
+          # so we should add a new one on the stack.
+          # Example: https://github.com/rails/rails/blob/ce49fa9b31cd4a21d43db39d0cea364bce28b51d/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L337
+          if stacks[connection_id].last == :raw
+            # Update the type of the last transaction event
+            stacks[connection_id].pop
+            stacks[connection_id] << :transaction
+          else
+            stacks[connection_id] << :transaction
+            Isolator.incr_transactions!(connection_id)
+          end
+        end
+      end
+
+      def finish(event, id, payload)
+        if event.start_with?("sql.")
+          if start_event?(payload[:sql])
+            connection_id = extract_connection_id(payload)
+
+            stacks[connection_id] << :raw
+
+            Isolator.incr_transactions!(connection_id)
+          end
+
+          if finish_event?(payload[:sql])
+            connection_id = extract_connection_id(payload)
+
+            # Decrement only if the transaction was started in the raw mode,
+            # otherwise we should wait for the "transaction" event
+            if stacks[connection_id].last == :raw
+              stacks[connection_id].pop
+              Isolator.decr_transactions!(connection_id)
+            end
+          end
+        end
+
+        if event.start_with?("transaction.")
+          connection_id = extract_transaction_connection_id(payload)
+          stacks[connection_id].pop
+
+          Isolator.decr_transactions!(connection_id)
+        end
+      end
+
+      private
+
+      def extract_transaction_connection_id(payload)
+        payload[:connection]&.object_id || 0
+      end
+    end
+
+    def self.subscribe!(event = "transaction.active_record", sql_event = "sql.active_record")
+      subscriber = Subscriber.new
+      ::ActiveSupport::Notifications.subscribe(event, subscriber)
+      ::ActiveSupport::Notifications.subscribe(sql_event, subscriber)
+    end
+  end
+end

--- a/spec/isolator/orm_adapters/active_record_spec.rb
+++ b/spec/isolator/orm_adapters/active_record_spec.rb
@@ -30,6 +30,114 @@ describe "ActiveRecord integration" do
         expect(Isolator).to_not be_within_transaction
       end
     end
+
+    # Run this test only on PG, so we can terminate the connection from the outside
+    context "when connection is terminated while being within a transaction", skip: DB_CONFIG[:adapter] != "postgresql" do
+      it do
+        expect(Isolator).to_not be_within_transaction
+
+        expect do
+          conn_id_q = Queue.new
+          cont = Queue.new
+
+          t = Thread.new do
+            expect do
+              User.transaction do
+                User.create!(name: "test")
+                conn_id_q << User.connection.raw_connection.backend_pid
+                expect(Isolator).to be_within_transaction
+                cont.pop
+              end
+            end.to raise_error(ActiveRecord::StatementInvalid)
+
+            expect(Isolator).to_not be_within_transaction
+          end
+
+          conn_id = conn_id_q.pop
+
+          User.connection.execute("select pg_terminate_backend(#{conn_id})")
+
+          cont << true
+
+          t.join
+        end.not_to change(User, :count)
+
+        expect(Isolator).to_not be_within_transaction
+      end
+    end
+
+    context "when failed to commit", skip: !(ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1) do
+      it do
+        expect(Isolator).to_not be_within_transaction
+
+        expect do
+          # Uses the seconds database here with the persistent sqlite, so we do not lose schema
+          Post.transaction do
+            Post.create!(title: "test")
+            expect(Isolator).to be_within_transaction
+            allow(Post.connection).to receive(:commit_db_transaction).and_raise("Failed to commit")
+            allow(Post.connection).to receive(:rollback_db_transaction) {
+              raise "Failed to rollback"
+            }
+          end
+        end.to raise_error(/failed to rollback/i)
+
+        expect(Isolator).to_not be_within_transaction
+      end
+    end
+
+    context "when rolling back a restarting savepoint transaction", skip: !(ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1) do
+      specify do
+        expect(Isolator).to_not be_within_transaction
+
+        begin
+          # RealTransaction (begin..rollback)
+          ar_class.transaction do
+            ar_class.first
+            # Savepoint Transaction (savepoint..rollback)
+            ar_class.transaction(requires_new: true) do
+              # ResetParentTransaction (rollback to outer savepoint)
+              ar_class.transaction(requires_new: true) do
+                ar_class.first
+                expect(Isolator).to be_within_transaction
+                raise ActiveRecord::Rollback
+              end
+
+              ar_class.first
+            end
+            ar_class.first
+          ensure
+            expect(Isolator).to be_within_transaction
+          end
+        rescue
+        end
+
+        expect(Isolator).to_not be_within_transaction
+      end
+    end
+
+    context "with lazy and non-lazy nested transactions" do
+      specify do
+        expect(Isolator).to_not be_within_transaction
+
+        begin
+          ar_class.connection.begin_transaction(joinable: false)
+          ar_class.connection.begin_transaction(joinable: false, _lazy: false)
+
+          ar_class.transaction(requires_new: true) do
+            ar_class.first
+            expect(Isolator).to be_within_transaction
+          end
+
+          expect(Isolator).to be_within_transaction
+        ensure
+          ar_class.connection.rollback_transaction
+          ar_class.connection.rollback_transaction
+        end
+
+        expect(Isolator).to_not be_within_transaction
+      end
+    end
   end
 
   context "other transaction methods" do

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -10,8 +10,12 @@ require_relative "./action_mailer_init"
 require_relative "./active_job_init"
 
 class TestApp < Rails::Application
-  secrets.secret_token = "secret_token"
-  secrets.secret_key_base = "secret_key_base"
+  config.secret_token = "secret_token"
+  config.secret_key_base = "secret_key_base"
+
+  if Rails::VERSION::MAJOR >= 6
+    config.load_defaults "#{Rails::VERSION::MAJOR}.0"
+  end
 
   config.eager_load = true
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Use a new Active Support Notifications event, `transaction.active_record`, to better handle transactions (especially, incomplete one).

Closes #64.
Closes #65. 

## What changes did you make? (overview)

- Added a new subscriber relying on both `transaction.active_record` and `sql.active_record` events. It's activated by default in Active Record 7.1+ (works with 7.1.0.beta1). Why both? See below.

## Is there anything you'd like reviewers to focus on?

Isolator aims to identify all transactions, even those not started via ActiveRecord APIs (e.g., `execute "begin; commit;"`). That's why we still rely on the `sql.active_record` and analyze queries in the first place. However, if the corresponding `transaction.active_record` event has been issued, we switch to only listening to it for a given transaction.

We assume that the `sql.active_record` and `transaction.active_record` events are fired in the specified order (current Rails 7.1. behavior).

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
