### PR TITLE
Use args forwarding in adapters

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,11 +24,8 @@ jobs:
         gemfile: ["gemfiles/rails6.gemfile"]
         db: [""]
         include:
-        - ruby: "2.6"
-          gemfile: "gemfiles/rails5.gemfile"
-          db: ""
         - ruby: "2.7"
-          gemfile: "gemfiles/rails5.gemfile"
+          gemfile: "gemfiles/rails6.gemfile"
           db: ""
         - ruby: "3.0"
           gemfile: "gemfiles/rails7.gemfile"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /tmp/
 *.gem
 gemfiles/*.lock
-Gemfile.local
+Gemfile.local*
 .rspec_status
 .idea
+*.sqlite3*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,6 @@ AllCops:
     - 'lib/generators/**/templates/*.rb'
   DisplayCopNames: true
   SuggestExtensions: false
-  TargetRubyVersion: 2.7
 
 Standard/BlockSingleLineBraces:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - 'lib/generators/**/templates/*.rb'
   DisplayCopNames: true
   SuggestExtensions: false
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Standard/BlockSingleLineBraces:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Drop Ruby 2.6 and Rails 5 support. ([@palkan][])
+
 ## 0.11.0 (2023-09-27)
 
 - Use Rails new `transaction.active_record` event if available to better handle edge cases. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Isolator relies on [uniform_notifier][] to send custom notifications.
 
 ### Supported ORMs
 
-- `ActiveRecord` >= 5.1 (4.2 likely till works, but we do not test against it anymore)
+- `ActiveRecord` >= 6.0 (see older versions of Isolator for previous versions)
 - `ROM::SQL` (only if Active Support instrumentation extension is loaded)
 
 ### Adapters

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 5.0"
-gem "sqlite3", "~> 1.3"
-
-gemspec path: ".."

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org" do
   gem "rubocop-md"
-  gem "standard", "~> 1.0.0"
+  gem "standard", "~> 1.0"
 end

--- a/isolator.gemspec
+++ b/isolator.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/palkan/isolator"
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.files = Dir.glob("lib/**/*") + %w[README.md LICENSE.txt CHANGELOG.md]
 

--- a/lib/isolator/adapters/base.rb
+++ b/lib/isolator/adapters/base.rb
@@ -27,8 +27,8 @@ module Isolator
         Isolator.notify(exception: build_exception(obj, args, kwargs), backtrace: backtrace)
       end
 
-      def notify?(*args, **kwargs)
-        enabled? && Isolator.enabled? && Isolator.within_transaction? && !ignored?(*args, **kwargs)
+      def notify?(...)
+        enabled? && Isolator.enabled? && Isolator.within_transaction? && !ignored?(...)
       end
 
       def ignore_if(&block)

--- a/lib/isolator/adapters/http/sniffer.rb
+++ b/lib/isolator/adapters/http/sniffer.rb
@@ -6,12 +6,12 @@ require "sniffer"
 Sniffer::Config.defaults["logger"] = nil
 
 Isolator.isolate :http, target: Sniffer.singleton_class,
-                        method_name: :store,
-                        exception_class: Isolator::HTTPError,
-                        details_message: ->(_obj, args) {
-                          req = args.first.request
-                          "#{req.method} #{req.host}:#{req.port}#{req.query}"
-                        }
+  method_name: :store,
+  exception_class: Isolator::HTTPError,
+  details_message: ->(_obj, args) {
+    req = args.first.request
+    "#{req.method} #{req.host}:#{req.port}#{req.query}"
+  }
 
 Isolator.before_isolate do
   next if Isolator.adapters.http.disabled?

--- a/lib/isolator/adapters/mailers/mail.rb
+++ b/lib/isolator/adapters/mailers/mail.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 Isolator.isolate :mailer, target: Mail::Message,
-                          method_name: :deliver,
-                          exception_class: Isolator::MailerError,
-                          details_message: ->(obj) {
-                            "From: #{obj.from}\n" \
-                            "To: #{obj.to}\n" \
-                            "Subject: #{obj.subject}"
-                          }
+  method_name: :deliver,
+  exception_class: Isolator::MailerError,
+  details_message: ->(obj) {
+    "From: #{obj.from}\n" \
+    "To: #{obj.to}\n" \
+    "Subject: #{obj.subject}"
+  }

--- a/lib/isolator/orm_adapters/active_record.rb
+++ b/lib/isolator/orm_adapters/active_record.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "./active_support_subscriber"
+require_relative "active_support_subscriber"
 
 # We rely on this feature introduced in 7.1.0.beta1: https://github.com/rails/rails/pull/49192
 if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
-  require_relative "./active_support_transaction_subscriber"
+  require_relative "active_support_transaction_subscriber"
   Isolator::ActiveSupportTransactionSubscriber.subscribe!
 else
   Isolator::ActiveSupportSubscriber.subscribe!("sql.active_record")

--- a/lib/isolator/orm_adapters/rom_active_support.rb
+++ b/lib/isolator/orm_adapters/rom_active_support.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./active_support_subscriber"
+require_relative "active_support_subscriber"
 
 Isolator::ActiveSupportSubscriber.subscribe!("sql.rom")

--- a/spec/isolator/adapters/base_spec.rb
+++ b/spec/isolator/adapters/base_spec.rb
@@ -11,7 +11,7 @@ describe "Base adapter" do
     end
 
     Isolator.isolate :test, target: ::Isolator::Danger.singleton_class,
-                            method_name: :call
+      method_name: :call
   end
 
   after(:all) do

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -5,9 +5,9 @@ require "action_controller/railtie"
 
 require "isolator"
 
-require_relative "./active_record_init"
-require_relative "./action_mailer_init"
-require_relative "./active_job_init"
+require_relative "active_record_init"
+require_relative "action_mailer_init"
+require_relative "active_job_init"
 
 class TestApp < Rails::Application
   config.secret_token = "secret_token"
@@ -30,6 +30,6 @@ class TestApp < Rails::Application
   end
 end
 
-require_relative "./workers/active_job_worker"
+require_relative "workers/active_job_worker"
 
 TestApp.initialize!

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -13,9 +13,7 @@ class TestApp < Rails::Application
   config.secret_token = "secret_token"
   config.secret_key_base = "secret_key_base"
 
-  if Rails::VERSION::MAJOR >= 6
-    config.load_defaults "#{Rails::VERSION::MAJOR}.0"
-  end
+  config.load_defaults "#{Rails::VERSION::MAJOR}.0"
 
   config.eager_load = true
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Refactor to use modern Ruby features to inject custom logic into third-party classes.

Fixes #70 .

## What changes did you make? (overview)

- [x] Refactored AdapterBuilder to use `foo(...)` instead of `foo(*args,**kwargs,&block)`.

## Is there anything you'd like reviewers to focus on?

Dropped Ruby <2.7 and Rails 5 support.

## Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
