### PR TITLE
Support `ActiveJob` 7.2 `enqueue_after_transaction_commit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add support for `ActiveJob::Base.enqueue_after_transaction_commit`. ([@joshuay03][])
+
 - Add `ignore_on: (obj) -> bool` option for adapters. ([@palkan][])
 
 - Add ActionCable adapter. ([@arthurWD][])
@@ -145,3 +147,5 @@ This, for example, makes Isolator compatible with Rails multi-database apps.
 [@Mange]: https://github.com/Mange
 [@tomgi]: https://github.com/tomgi
 [@tagirahmad]: https://github.com/tagirahmad
+[@arthurWD]: https://github.com/arthurWD
+[@joshuay03]: https://github.com/joshuay03

--- a/lib/isolator/adapters/background_jobs/active_job.rb
+++ b/lib/isolator/adapters/background_jobs/active_job.rb
@@ -7,4 +7,9 @@ Isolator.isolate :active_job,
   details_message: ->(obj) {
     "#{obj.class.name}" \
     "#{obj.arguments.any? ? " (#{obj.arguments.join(", ")})" : ""}"
-  }
+  },
+  ignore_on: ->(job) {
+               config = job.class.try(:enqueue_after_transaction_commit)
+               config == :always || (config == :default &&
+                 ActiveJob::Base.queue_adapter.try(:enqueue_after_transaction_commit?) == true)
+             }

--- a/spec/isolator/adapters/background_jobs/active_job_spec.rb
+++ b/spec/isolator/adapters/background_jobs/active_job_spec.rb
@@ -17,5 +17,77 @@ describe "ActiveJob adapter" do
     specify do
       expect { ActiveJobWorker.perform_later("test") }.to raise_error(Isolator::BackgroundJobError, /ActiveJobWorker.+test/)
     end
+
+    context "with enqueue_after_transaction_commit", :rails72 do
+      after { reset_enqueue_after_transaction_commit }
+
+      context "configured to :always" do
+        before { set_enqueue_after_transaction_commit_to :always }
+
+        specify do
+          expect { ActiveJobWorker.perform_later("test") }.to_not raise_error
+        end
+
+        context "job class configured to :never" do
+          before { ActiveJobWorker.enqueue_after_transaction_commit = :never }
+
+          specify do
+            expect(ActiveJob::Base.enqueue_after_transaction_commit).to eq :always
+            expect { ActiveJobWorker.perform_later("test") }.to raise_error(Isolator::BackgroundJobError, /ActiveJobWorker.+test/)
+          end
+        end
+      end
+
+      context "configured to :default" do
+        before { set_enqueue_after_transaction_commit_to :default }
+
+        context "with queue_adapter enqueue_after_transaction_commit enabled" do
+          before do
+            allow(ActiveJob::Base.queue_adapter).to receive(:enqueue_after_transaction_commit?) { true }
+          end
+
+          specify do
+            expect { ActiveJobWorker.perform_later("test") }.to_not raise_error
+          end
+        end
+
+        context "with queue_adapter enqueue_after_transaction_commit disabled" do
+          before do
+            allow(ActiveJob::Base.queue_adapter).to receive(:enqueue_after_transaction_commit?) { false }
+          end
+
+          specify do
+            expect { ActiveJobWorker.perform_later("test") }.to raise_error(Isolator::BackgroundJobError, /ActiveJobWorker.+test/)
+          end
+        end
+      end
+
+      context "configured to :never" do
+        before { set_enqueue_after_transaction_commit_to :never }
+
+        specify do
+          expect { ActiveJobWorker.perform_later("test") }.to raise_error(Isolator::BackgroundJobError, /ActiveJobWorker.+test/)
+        end
+      end
+
+      private
+
+      def set_enqueue_after_transaction_commit_to(value)
+        Rails.application.config.active_job.enqueue_after_transaction_commit = value
+        run_enqueue_after_transaction_commit_initializer
+        ActiveJobWorker.enqueue_after_transaction_commit = value # manually (re)set for subclass
+      end
+
+      def reset_enqueue_after_transaction_commit
+        Rails.application.config.active_job.enqueue_after_transaction_commit = :default
+        run_enqueue_after_transaction_commit_initializer
+        ActiveJobWorker.enqueue_after_transaction_commit = :default # manually (re)set for subclass
+        allow(ActiveJob::Base.queue_adapter).to receive(:enqueue_after_transaction_commit?) { true }
+      end
+
+      def run_enqueue_after_transaction_commit_initializer
+        Rails.application.initializers.find { |i| i.name == "active_job.enqueue_after_transaction_commit" }.run
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,10 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 RSpec.configure do |config|
   config.example_status_persistence_file_path = ".rspec_status"
   config.filter_run focus: true
+  # TODO: replace with `Rails.version >= Gem::Version.new("7.2")` once 7.2 is released
+  unless Rails::VERSION::MAJOR >= 7 && Rails::VERSION::MINOR >= 2
+    config.filter_run_excluding :rails72
+  end
   config.run_all_when_everything_filtered = true
 
   config.order = :random

--- a/spec/support/active_job_init.rb
+++ b/spec/support/active_job_init.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_job/railtie"
 require "active_job"
 
 ActiveJob::Base.queue_adapter = :test


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Ref: https://github.com/rails/rails/pull/51426

Disables the throwing of `Isolator::BackgroundJobError` for  jobs queued from within transactions if the new `ActiveJob` config `enqueue_after_transaction_commit` is enabled.

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

Updated the `active_job` adapter to be disabled if `enqueue_after_transaction_commit` is enabled globally or by the configured queue adapter.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
