### PR TITLE
Fix `ThreadStateProxy` to use namespaced thread-local variables

### DIFF
--- a/lib/isolator.rb
+++ b/lib/isolator.rb
@@ -20,7 +20,7 @@ module Isolator
   class ThreadStateProxy
     attr_reader :prefix
 
-    def initilize(prefix = "isolator_")
+    def initialize(prefix = "isolator_")
       @prefix = prefix
     end
 

--- a/spec/isolator/thread_state_proxy_spec.rb
+++ b/spec/isolator/thread_state_proxy_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Isolator::ThreadStateProxy do
+  subject { described_class.new("isolator_") }
+
+  after { Thread.current["isolator_key"] = nil }
+
+  describe "#[]" do
+    before { Thread.current["isolator_key"] = "isolator-value" }
+
+    it "fetches value indexed by prefixed key" do
+      expect(subject["key"]).to eq("isolator-value")
+    end
+  end
+
+  describe "#[]=" do
+    it "stores value indexed by prefixed key" do
+      subject["key"] = "isolator-value"
+
+      expect(Thread.current["isolator_key"]).to eq("isolator-value")
+    end
+  end
+end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

I've been trying to fix a bug related to occasional CI failures caused by false-positive (?) isolator offenses (it might be a race condition somewhere in AR, not sure yet). During debugging, I noticed that `ThreadStateProxy` does not actually use the prefix namespace.

## What changes did you make? (overview)

Fixed typo in `initialize`, actually 🙂 

## Is there anything you'd like reviewers to focus on?

## Checklist

- [X] I've added tests for this change
- [ ] I've added a Changelog entry
