### PR TITLE
chore: rename disallow_cross_database_transactions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Isolator.configure do |config|
   config.ignorer = Isolator::Ignorer
 
   # Turn on/off raising exceptions for simultaneous transactions to different databases
-  config.disallow_cross_database_transactions = false
+  config.disallow_per_thread_concurrent_transactions = false
 end
 ```
 


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

This configuration key is not supported anymore on v1.1.1 and has been renamed to `disallow_per_thread_concurrent_transactions`

## What changes did you make? (overview)

- Update `README.md` to reflect the new config key name

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [X] I've updated a documentation
