### PR TITLE
Fix `database_cleaner` support: require `base.rb` explicitly

### DIFF
--- a/lib/isolator/database_cleaner_support.rb
+++ b/lib/isolator/database_cleaner_support.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "database_cleaner/active_record/base"
 require "database_cleaner/active_record/transaction"
 ::DatabaseCleaner::ActiveRecord::Transaction.prepend(
   Module.new do


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Since https://github.com/DatabaseCleaner/database_cleaner-active_record/pull/104 `database_cleaner/active_record/transaction.rb` does not require `base.rb`, so [tests fail with ](https://github.com/viralpraxis/isolator/actions/runs/16159285466/job/45607720135#step:6:412)"uninitialized constant DatabaseCleaner::ActiveRecord::Base" error.

I think this issue only affect Isolator's tests, but it seems to be safe to just require `base.rb` explicitly in the `database_cleaner_support.rb` itself. Let me know if we want to move it to the specs.

## What changes did you make? (overview)

See above

## Is there anything you'd like reviewers to focus on?

Nope

## Checklist

- [ ] I've added tests for this change (tests now pass)
- [ ] I've added a Changelog entry (not necessary I think)
- [ ] I've updated a documentation
