### PR TITLE
Fix mid-transaction connection switch issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix mid-transaction connection switch issue. ([@viralpraxis][])
+
 ## 1.2.0 (2025-11-07)
 
 - Use `ActiveRecord::Base.lease_connection` instead of `ActiveRecord::Base.connection`, if available. ([@viralpraxis][])

--- a/lib/isolator.rb
+++ b/lib/isolator.rb
@@ -185,6 +185,14 @@ module Isolator
       false
     end
 
+    def set_current_connection_id(connection_id, context:)
+      state["#{context}_connection_id"] = connection_id
+    end
+
+    def current_connection_id(context:)
+      state["#{context}_connection_id"]
+    end
+
     def enabled?
       !disabled?
     end

--- a/lib/isolator/database_cleaner_support.rb
+++ b/lib/isolator/database_cleaner_support.rb
@@ -6,9 +6,9 @@ require "database_cleaner/active_record/transaction"
   Module.new do
     def start
       super
-
       connection_id = connection.object_id
 
+      Isolator.set_current_connection_id(connection_id, context: :database_cleaner)
       Isolator.set_connection_threshold(
         Isolator.transactions_threshold(connection_id) + 1,
         connection_id
@@ -18,6 +18,7 @@ require "database_cleaner/active_record/transaction"
     def clean
       connection_id = connection.object_id
 
+      return unless connection_id == Isolator.current_connection_id(context: :database_cleaner)
       Isolator.set_connection_threshold(
         Isolator.transactions_threshold(connection_id) - 1,
         connection_id


### PR DESCRIPTION
Resolves https://github.com/palkan/isolator/issues/83

Apparently, there's [another issue on the Rails side](https://github.com/rails/rails/issues/55306) so Isolator's failure is just a symptom. Still, I think it makes sense to check `connection_id` explicitly and skip threshold change in case of connection switching, since it's an implicit invariant.

## Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
