### PR TITLE
Fix Rails 8.0 support

### DIFF
--- a/lib/isolator/orm_adapters/active_record.rb
+++ b/lib/isolator/orm_adapters/active_record.rb
@@ -3,7 +3,7 @@
 require_relative "active_support_subscriber"
 
 # We rely on this feature introduced in 7.1.0.beta1: https://github.com/rails/rails/pull/49192
-if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+if ActiveRecord.version >= "7.1"
   require_relative "active_support_transaction_subscriber"
   Isolator::ActiveSupportTransactionSubscriber.subscribe!
 else


### PR DESCRIPTION
## What is the purpose of this pull request?

When checking for Rails 8.0.2, the adapter used is the wrong one, making `Isolator.adapters.active_job.disable!` not do anything when trying to upgrade Rails.

## What changes did you make? (overview)

Used a better version matcher.

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
