### PR TITLE
Fix RuboCop `Style/EmptyStringInsideInterpolation` offense

### DIFF
--- a/lib/isolator/adapters/background_jobs/active_job.rb
+++ b/lib/isolator/adapters/background_jobs/active_job.rb
@@ -6,7 +6,7 @@ Isolator.isolate :active_job,
   exception_class: Isolator::BackgroundJobError,
   details_message: ->(obj) {
     "#{obj.class.name}" \
-    "#{obj.arguments.any? ? " (#{obj.arguments.join(", ")})" : ""}"
+    "#{" (#{obj.arguments.join(", ")})" if obj.arguments.any?}"
   },
   ignore_on: ->(job) {
                config = job.class.try(:enqueue_after_transaction_commit)


### PR DESCRIPTION
```shell
lib/isolator/adapters/background_jobs/active_job.rb:9:8: C: [Corrected] Style/EmptyStringInsideInterpolation: Do not return empty strings in string interpolation.
    "#{obj.arguments.any? ? " (#{obj.arguments.join(", ")})" : ""}"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
````
